### PR TITLE
Futurize the code (add Python 3 and Python 2 compatibility)

### DIFF
--- a/pyitlib/discrete_random_variable.py
+++ b/pyitlib/discrete_random_variable.py
@@ -107,7 +107,12 @@ International Symposium on Information Theory, 2006, P. 98-102.
 correlation. In: IBM Journal of research and development, \
 Vol. 4, No. 1, 1960, P. 66-82.
 """
+from __future__ import division
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import warnings
 import numpy as np
 import sklearn.preprocessing
@@ -1013,7 +1018,7 @@ def information_binding(X, base=2, fill_value=-1, estimator='ML',
     Alphabet_X = np.reshape(Alphabet_X, (-1, Alphabet_X.shape[-1]))
     M = np.arange(X.shape[0])
 
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         B -= H_joint
         if X.shape[0] > 1:
             B += entropy_joint(X[M != i], base, fill_value, estimator,
@@ -1385,7 +1390,7 @@ def information_mutual_conditional(X, Y, Z, cartesian_product=False, base=2,
         Z = np.reshape(Z, (-1, Z.shape[-1]))
         Alphabet_Z = np.reshape(Alphabet_Z, (-1, Alphabet_Z.shape[-1]))
         I = []
-        for i in xrange(Z.shape[0]):
+        for i in range(Z.shape[0]):
             def f(X, Y, Alphabet_X, Alphabet_Y):
                 return information_mutual_conditional(X, Y, Z[i], False, base,
                                                       fill_value, estimator,
@@ -1412,7 +1417,7 @@ def information_mutual_conditional(X, Y, Z, cartesian_product=False, base=2,
     orig_shape_I = I.shape
     I = np.reshape(I, (-1, 1))
 
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         I_ = (entropy_joint(np.vstack((X[i], Z[i])), base, fill_value,
                             estimator,
                             _vstack_pad((Alphabet_X[i],
@@ -1674,7 +1679,7 @@ def information_lautum(X, Y=None, cartesian_product=False, base=2,
     _verify_alphabet_sufficiently_large(X, Alphabet_X, fill_value)
     _verify_alphabet_sufficiently_large(Y, Alphabet_Y, fill_value)
 
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         # Sort X and Y jointly, so that we can determine joint symbol
         # probabilities
         JointXY = np.vstack((X[i], Y[i]))
@@ -1712,7 +1717,7 @@ def information_lautum(X, Y=None, cartesian_product=False, base=2,
         alphabet_Y = np.unique(alphabet_XY[1])
         P_XY_reshaped = np.zeros((alphabet_Y.size, alphabet_X.size))
         j = k = c = 0
-        for c in xrange(P_XY.size):
+        for c in range(P_XY.size):
             if c > 0 and alphabet_XY[1, c] != alphabet_XY[1, c-1]:
                 k = 0
             while alphabet_X[k] != alphabet_XY[0, c]:
@@ -2056,7 +2061,7 @@ def information_mutual_normalised(X, Y=None, norm_factor='Y',
             orig_shape_H = H.shape
             H = np.reshape(H, (-1, 1))
 
-            for i in xrange(X.shape[0]):
+            for i in range(X.shape[0]):
                 H[i] = entropy_joint(np.vstack((X[i], Y[i])),
                                      fill_value=fill_value,
                                      estimator=estimator,
@@ -2090,7 +2095,7 @@ def information_mutual_normalised(X, Y=None, norm_factor='Y',
     else:
         raise ValueError("arg norm_factor has invalid value")
 
-    I = I / C
+    I = old_div(I, C)
 
     if keep_dims and not cartesian_product:
         I = I[..., np.newaxis]
@@ -2637,7 +2642,7 @@ def entropy_cross(X, Y=None, cartesian_product=False, base=2, fill_value=-1,
     # Compute symbol change indicators
     B = X[:, 1:] != X[:, :-1]
     C = Y[:, 1:] != Y[:, :-1]
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         # Obtain symbol change positions
         I = np.append(np.where(B[i]), X.shape[1]-1)
         # Compute run lengths
@@ -3067,7 +3072,7 @@ def divergence_jensenshannon(X, Y=None, cartesian_product=False, base=2,
     # Compute symbol change indicators
     B = X[:, 1:] != X[:, :-1]
     C = Y[:, 1:] != Y[:, :-1]
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         # Obtain symbol change positions
         I = np.append(np.where(B[i]), X.shape[1]-1)
         # Compute run lengths
@@ -3509,7 +3514,7 @@ def entropy_conditional(X, Y=None, cartesian_product=False, base=2,
     orig_shape_H = H.shape
     H = np.reshape(H, (-1, 1))
 
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         H[i] = entropy_joint(np.vstack((X[i], Y[i])), base, fill_value,
                              estimator, _vstack_pad((Alphabet_X[i],
                                                      Alphabet_Y[i]),
@@ -3674,7 +3679,7 @@ def entropy_joint(X, base=2, fill_value=-1, estimator='ML', Alphabet_X=None,
     _verify_alphabet_sufficiently_large(X, Alphabet_X, fill_value)
 
     # Sort columns
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         X = X[:, X[i].argsort(kind='mergesort')]
 
     # Compute symbol run-lengths
@@ -3860,7 +3865,7 @@ def entropy(X, base=2, fill_value=-1, estimator='ML', Alphabet_X=None,
     # Compute symbol run-lengths
     # Compute symbol change indicators
     B = X[:, 1:] != X[:, :-1]
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         # Obtain symbol change positions
         I = np.append(np.where(B[i]), X.shape[1]-1)
         # Compute run lengths
@@ -3943,7 +3948,7 @@ def entropy_pmf(P, base=2, require_valid_pmf=True, keep_dims=False):
         raise ValueError("arg base not a positive real-valued scalar")
 
     H = -np.sum(P * np.log2(P + np.spacing(0)), axis=-1)
-    H = H / np.log2(base)
+    H = old_div(H, np.log2(base))
 
     if keep_dims:
         H = H[..., np.newaxis]
@@ -4050,7 +4055,7 @@ def entropy_cross_pmf(P, Q=None, cartesian_product=False, base=2,
         H = P * np.log2(Q)
     H[P == 0] = 0
     H = -np.sum(H, axis=-1)
-    H = H / np.log2(base)
+    H = old_div(H, np.log2(base))
 
     if keep_dims and not cartesian_product:
         H = H[..., np.newaxis]
@@ -4354,8 +4359,8 @@ def _append_empty_bins_using_alphabet(Counts, Alphabet, Full_Alphabet,
         Alph2 = np.unique(Full_Alphabet[1, Full_Alphabet[1] != fill_value])
         A = np.zeros((2, Alph1.size*Alph2.size), dtype=Full_Alphabet.dtype)
         c = 0
-        for j in xrange(Alph2.size):
-            for i in xrange(Alph1.size):
+        for j in range(Alph2.size):
+            for i in range(Alph1.size):
                 A[0, c] = Alph1[i]
                 A[1, c] = Alph2[j]
                 c = c + 1
@@ -4373,7 +4378,7 @@ def _append_empty_bins_using_alphabet(Counts, Alphabet, Full_Alphabet,
         Alphabet = np.hstack((Alphabet, A[:, Unseen]))
         Counts = np.append(Counts, np.tile(0, Alphabet.size-Counts.size))
         # Sort columns
-        for i in xrange(Alphabet.shape[0]):
+        for i in range(Alphabet.shape[0]):
             I = Alphabet[i].argsort(kind='mergesort')
             Alphabet = Alphabet[:, I]
             Counts = Counts[I]
@@ -4446,8 +4451,8 @@ def _cartesian_product_apply(X, Y, function, Alphabet_X=None, Alphabet_Y=None):
     H = np.reshape(H, (-1, 1))
 
     n = 0
-    for i in xrange(X.shape[0]):
-        for j in xrange(Y.shape[0]):
+    for i in range(X.shape[0]):
+        for j in range(Y.shape[0]):
             if Alphabet_X is not None or Alphabet_Y is not None:
                 H[n] = function(X[i], Y[j], Alphabet_X[i], Alphabet_Y[j])
             else:
@@ -4495,18 +4500,18 @@ def _estimate_probabilities(Counts, estimator, n_additional_empty_bins=0):
         if np.isreal(estimator):
             alpha = estimator
         elif estimator == 'PERKS':
-            alpha = 1.0 / (Counts.size+n_additional_empty_bins)
+            alpha = old_div(1.0, (Counts.size+n_additional_empty_bins))
         elif estimator == 'MINIMAX':
-            alpha = np.sqrt(np.sum(Counts)) / \
-                (Counts.size+n_additional_empty_bins)
+            alpha = old_div(np.sqrt(np.sum(Counts)), \
+                (Counts.size+n_additional_empty_bins))
         else:
             alpha = 0
-        Theta = (Counts+alpha) / \
-            (1.0*np.sum(Counts) + alpha*(Counts.size+n_additional_empty_bins))
+        Theta = old_div((Counts+alpha), \
+            (1.0*np.sum(Counts) + alpha*(Counts.size+n_additional_empty_bins)))
         # Theta_0 is the probability mass assigned to each additional empty bin
         if n_additional_empty_bins > 0:
-            Theta_0 = alpha / (1.0*np.sum(Counts) +
-                               alpha*(Counts.size+n_additional_empty_bins))
+            Theta_0 = old_div(alpha, (1.0*np.sum(Counts) +
+                               alpha*(Counts.size+n_additional_empty_bins)))
         else:
             Theta_0 = 0
 
@@ -4528,7 +4533,7 @@ def _estimate_probabilities(Counts, estimator, n_additional_empty_bins=0):
         Q = np.append(0, R[:-1])
         T = np.append(R[1:], 2*R[-1]-Q[-1])
         Z_r = np.zeros_like(N_r)
-        Z_r[R] = N_r[R] / (0.5*(T-Q))
+        Z_r[R] = old_div(N_r[R], (0.5*(T-Q)))
 
         # Fit least squares regression line to plot of log(Z_r) versus log(r)
         x = np.log10(np.arange(1, Z_r.size))
@@ -4553,7 +4558,7 @@ def _estimate_probabilities(Counts, estimator, n_additional_empty_bins=0):
         with np.errstate(invalid='ignore', divide='ignore'):
             VARr_T = (np.arange(N_r.size)+1)**2 * \
                 (1.0*np.append(N_r[1:], 0)/(N_r**2)) * \
-                (1 + np.append(N_r[1:], 0)/N_r)
+                (1 + old_div(np.append(N_r[1:], 0),N_r))
             x = (np.arange(N_r.size)+1) * 1.0*np.append(N_r[1:], 0) / N_r
             y = (np.arange(N_r.size)+1) * \
                 1.0*SmoothedN_r[1:] / (SmoothedN_r[:-1])
@@ -4591,12 +4596,12 @@ def _estimate_probabilities(Counts, estimator, n_additional_empty_bins=0):
             warnings.warn("No unobserved outcomes specified. Disregarding the "
                           "probability mass allocated to any unobserved "
                           "outcomes.")
-            Theta = Theta / np.sum(Theta)
+            Theta = old_div(Theta, np.sum(Theta))
 
         # Divide p_0 among unobserved symbols
         with np.errstate(invalid='ignore', divide='ignore'):
-            p_emptybin = p_r[0] / (np.sum(Counts == 0) +
-                                   n_additional_empty_bins)
+            p_emptybin = old_div(p_r[0], (np.sum(Counts == 0) +
+                                   n_additional_empty_bins))
         Theta[Counts == 0] = p_emptybin
         # Theta_0 is the probability mass assigned to each additional empty bin
         if n_additional_empty_bins > 0:
@@ -4606,12 +4611,12 @@ def _estimate_probabilities(Counts, estimator, n_additional_empty_bins=0):
 
     elif estimator == 'JAMES-STEIN':
         Theta, _ = _estimate_probabilities(Counts, 'ML')
-        p_uniform = 1.0 / (Counts.size + n_additional_empty_bins)
+        p_uniform = old_div(1.0, (Counts.size + n_additional_empty_bins))
         with np.errstate(invalid='ignore', divide='ignore'):
-            Lambda = (1-np.sum(Theta**2)) / \
+            Lambda = old_div((1-np.sum(Theta**2)), \
                 ((np.sum(Counts)-1) *
                  (np.sum((p_uniform-Theta)**2) +
-                  n_additional_empty_bins*p_uniform**2))
+                  n_additional_empty_bins*p_uniform**2)))
 
         if Lambda > 1:
             Lambda = 1
@@ -4638,7 +4643,7 @@ def _increment_binary_vector(X):
     if not x:
         carry_1 = True
     X[0] = x
-    for i in xrange(1, X.size):
+    for i in range(1, X.size):
         x = X[i] ^ carry_1
         if not X[i] and x:
             carry_1 = False
@@ -4741,7 +4746,7 @@ def _sanitise_array_input(X, fill_value=-1):
 def _verify_alphabet_sufficiently_large(X, Alphabet, fill_value):
     assert(not np.any(X == np.array(None)))
     assert(not np.any(Alphabet == np.array(None)))
-    for i in xrange(X.shape[0]):
+    for i in range(X.shape[0]):
         I = X[i] != fill_value
         J = Alphabet[i] != fill_value
         # NB: This causes issues when both arguments contain None. But it is

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         'pandas>=0.20.2'
         'numpy>=1.9.2',
         'scikit-learn>=0.16.0',
-        'scipy>=1.0.1'
+        'scipy>=1.0.1',
+        'future==0.16.0'
     ],
     keywords=['entropy', 'information theory', 'Shannon information',
               'uncertainty', 'correlation', 'statistics',

--- a/tests/test_discrete_random_variable.py
+++ b/tests/test_discrete_random_variable.py
@@ -9,6 +9,9 @@
 #
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 from scipy.stats.distributions import norm
 import unittest
@@ -21,7 +24,7 @@ class TestEntropy(unittest.TestCase):
     def test_entropy_pmf(self):
         #Immutability test
         X1 = np.random.randint(16, size=(10,10))
-        X1 = X1 / (1.0 * np.sum(X1, axis=1)[:,np.newaxis])
+        X1 = old_div(X1, (1.0 * np.sum(X1, axis=1)[:,np.newaxis]))
         X2 = np.copy(X1)
         discrete.entropy_pmf(X2)
         self.assertTrue(np.all(X2 == X1))
@@ -37,7 +40,7 @@ class TestEntropy(unittest.TestCase):
         
         #Output dimensionality tests -- vectors
         self.assertTrue(discrete.entropy_pmf(np.array(((1.0,), (1.0,), (1.0,)))).shape == (3,))
-        self.assertTrue(discrete.entropy_pmf(np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T).shape == (1,))
+        self.assertTrue(discrete.entropy_pmf(np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T).shape == (1,))
         
         self.assertTrue(discrete.entropy_pmf(np.array(1)) == 0)
         self.assertTrue(discrete.entropy_pmf(np.array((1,))) == 0)
@@ -45,14 +48,14 @@ class TestEntropy(unittest.TestCase):
         self.assertTrue(discrete.entropy_pmf(np.ones((1,1))) == 0)
         
         X = np.ones((3,4,5))
-        X = X / (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis])
+        X = old_div(X, (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis]))
         self.assertTrue(isinstance(discrete.entropy_pmf(X), np.ndarray))
         self.assertTrue(discrete.entropy_pmf(X).shape == (3,4))                
         
         P1 = 1.0 * np.ones(int(1E06))
         P2 = 1.0 * np.ones(int(2E06))
-        H1 = discrete.entropy_pmf(P1 / np.sum(P1), base=2)
-        H2 = discrete.entropy_pmf(P2 / np.sum(P2), base=2)
+        H1 = discrete.entropy_pmf(old_div(P1, np.sum(P1)), base=2)
+        H2 = discrete.entropy_pmf(old_div(P2, np.sum(P2)), base=2)
         self.assertTrue(np.allclose(H1+1, H2))
                 
         np.random.seed(4759)
@@ -61,8 +64,8 @@ class TestEntropy(unittest.TestCase):
         Bins1 = np.linspace(-4,4,10000)
         P1 = 1.0 * np.bincount(np.digitize(X1, Bins1))
         P2 = 1.0 * np.bincount(np.digitize(X2, Bins1))
-        H1 = discrete.entropy_pmf(P1 / np.sum(P1), base=2)
-        H2 = discrete.entropy_pmf(P2 / np.sum(P2), base=2)
+        H1 = discrete.entropy_pmf(old_div(P1, np.sum(P1)), base=2)
+        H2 = discrete.entropy_pmf(old_div(P2, np.sum(P2)), base=2)
         self.assertTrue(abs(H1 - 1 - H2) < 1E-02)
         
         #Exception tests
@@ -82,10 +85,10 @@ class TestEntropy(unittest.TestCase):
     def test_entropy_cross_pmf(self):
         #Immutability test
         X1 = np.random.randint(16, size=(10,10))
-        X1 = X1 / (1.0 * np.sum(X1, axis=1)[:,np.newaxis])
+        X1 = old_div(X1, (1.0 * np.sum(X1, axis=1)[:,np.newaxis]))
         X1_copy = np.copy(X1)
         X2 = np.random.randint(16, size=(10,10))
-        X2 = X2 / (1.0 * np.sum(X2, axis=1)[:,np.newaxis])
+        X2 = old_div(X2, (1.0 * np.sum(X2, axis=1)[:,np.newaxis]))
         X2_copy = np.copy(X2)        
         discrete.entropy_cross_pmf(X1_copy, X2_copy)
         self.assertTrue(np.all(X1_copy == X1) and np.all(X2_copy == X2))
@@ -109,10 +112,10 @@ class TestEntropy(unittest.TestCase):
         
         #Output dimensionality tests -- vectors
         self.assertTrue(discrete.entropy_cross_pmf(np.array(((1.0,), (1.0,), (1.0,))), np.array(((1.0,), (1.0,), (1.0,)))).shape == (3,))
-        self.assertTrue(discrete.entropy_cross_pmf(np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T).shape == (1,))
+        self.assertTrue(discrete.entropy_cross_pmf(np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T).shape == (1,))
         #Tests using cartesian_product=True
         self.assertTrue(discrete.entropy_cross_pmf(np.array(((1.0,), (1.0,), (1.0,))), np.array(((1.0,), (1.0,), (1.0,))), cartesian_product=True).shape == (3,3))
-        self.assertTrue(discrete.entropy_cross_pmf(np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, cartesian_product=True).shape == (1,1))        
+        self.assertTrue(discrete.entropy_cross_pmf(np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, cartesian_product=True).shape == (1,1))        
 
         self.assertTrue(discrete.entropy_cross_pmf(np.array(1), np.array(1)) == 0)
         self.assertTrue(discrete.entropy_cross_pmf(np.array((1,)), np.array((1,))) == 0)
@@ -144,12 +147,12 @@ class TestEntropy(unittest.TestCase):
         self.assertTrue(discrete.entropy_cross_pmf(np.ones((1,1)),np.ones((1,1)),True).shape == (1,1))
         
         X = np.ones((3,4,5))
-        X = X / (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis])
+        X = old_div(X, (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis]))
         self.assertTrue(isinstance(discrete.entropy_cross_pmf(X,X), np.ndarray))
         self.assertTrue(discrete.entropy_cross_pmf(X,X).shape == (3,4))
         #Tests using cartesian_product=True
         X = np.ones((3,4,5))
-        X = X / (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis])
+        X = old_div(X, (1.0 * np.sum(X, axis=-1)[:,:,np.newaxis]))
         self.assertTrue(isinstance(discrete.entropy_cross_pmf(X,X,cartesian_product=True), np.ndarray))
         self.assertTrue(discrete.entropy_cross_pmf(X,X,cartesian_product=True).shape == (3,4,3,4))        
         
@@ -198,23 +201,23 @@ class TestEntropy(unittest.TestCase):
         self.assertTrue(discrete.divergence_kullbackleibler_pmf(np.ones((1,1)),np.ones((1,1)),True).shape == (1,1))
         
         P1 = 1.0 * np.ones(int(1E06))
-        H1 = discrete.divergence_kullbackleibler_pmf(P1 / np.sum(P1), P1 / np.sum(P1), base=2)
+        H1 = discrete.divergence_kullbackleibler_pmf(old_div(P1, np.sum(P1)), old_div(P1, np.sum(P1)), base=2)
         self.assertTrue(H1 == 0)
 
         Bins1 = np.linspace(-5,5,10000)
         P1 = norm.pdf(Bins1)
         P2 = norm.pdf(Bins1,loc=0.5)
-        H1 = discrete.divergence_kullbackleibler_pmf(P1 / np.sum(P1), P2 / np.sum(P2), base=np.exp(1))
+        H1 = discrete.divergence_kullbackleibler_pmf(old_div(P1, np.sum(P1)), old_div(P2, np.sum(P2)), base=np.exp(1))
         self.assertTrue(np.abs(H1 - 0.125) < 1E-3)
         
         Locs = np.linspace(-0.5,0.5,64)
         P1 = [norm.pdf(Bins1) for i in np.arange(64)]
         P2 = [norm.pdf(Bins1,Locs[i]) for i in np.arange(64)]
-        H1 = [(1 + loc**2)/2 - 0.5 for loc in Locs]              
+        H1 = [old_div((1 + loc**2),2) - 0.5 for loc in Locs]              
         P1 = np.array(P1).reshape((8,8,-1))
         P2 = np.array(P2).reshape((8,8,-1))
         H1 = np.array(H1).reshape((8,8))
-        H1_empirical = discrete.divergence_kullbackleibler_pmf(P1 / np.sum(P1,axis=-1)[:,:,np.newaxis], P2 / np.sum(P2,axis=-1)[:,:,np.newaxis], base=np.exp(1))
+        H1_empirical = discrete.divergence_kullbackleibler_pmf(old_div(P1, np.sum(P1,axis=-1)[:,:,np.newaxis]), old_div(P2, np.sum(P2,axis=-1)[:,:,np.newaxis]), base=np.exp(1))
         self.assertTrue(np.all(H1_empirical.shape == (8,8)))
         self.assertTrue(np.all(np.abs(H1 - H1_empirical) < 1E-3))
         
@@ -224,13 +227,13 @@ class TestEntropy(unittest.TestCase):
         P1 = np.array(P1).reshape((8,8,-1))
         P2 = np.array(P2).reshape((8,8,-1))
         Locs = Locs.reshape((8,8,-1))
-        H1_empirical = discrete.divergence_kullbackleibler_pmf(P1 / np.sum(P1,axis=-1)[:,:,np.newaxis], P2 / np.sum(P2,axis=-1)[:,:,np.newaxis], cartesian_product=True, base=np.exp(1))        
+        H1_empirical = discrete.divergence_kullbackleibler_pmf(old_div(P1, np.sum(P1,axis=-1)[:,:,np.newaxis]), old_div(P2, np.sum(P2,axis=-1)[:,:,np.newaxis]), cartesian_product=True, base=np.exp(1))        
         self.assertTrue(np.all(H1_empirical.shape == (8,8,8,8)))
-        for i in xrange(H1_empirical.shape[0]):
-            for j in xrange(H1_empirical.shape[1]):
-                for k in xrange(H1_empirical.shape[2]):
-                   for l in xrange(H1_empirical.shape[3]):
-                       H1 = (1 + (Locs[i,j]-Locs[k,l])**2)/2 - 0.5
+        for i in range(H1_empirical.shape[0]):
+            for j in range(H1_empirical.shape[1]):
+                for k in range(H1_empirical.shape[2]):
+                   for l in range(H1_empirical.shape[3]):
+                       H1 = old_div((1 + (Locs[i,j]-Locs[k,l])**2),2) - 0.5
                        self.assertTrue(np.abs(H1 - H1_empirical[i,j,k,l]) < 1E-3)
                        
     def test_divergence_kullbackleibler_symmetrised_pmf(self):
@@ -247,22 +250,22 @@ class TestEntropy(unittest.TestCase):
         self.assertTrue(discrete.divergence_kullbackleibler_symmetrised_pmf(np.ones((1,1)),np.ones((1,)),True).shape == (1,))
         self.assertTrue(discrete.divergence_kullbackleibler_symmetrised_pmf(np.ones((1,1)),np.ones((1,1)),True).shape == (1,1))        
         
-        self.assertTrue(np.allclose(discrete.divergence_kullbackleibler_symmetrised_pmf(np.array((2.0/3, 1.0/3)), np.array((1.0/3, 2.0/3))), 2.0/3))
+        self.assertTrue(np.allclose(discrete.divergence_kullbackleibler_symmetrised_pmf(np.array((old_div(2.0,3), old_div(1.0,3))), np.array((old_div(1.0,3), old_div(2.0,3)))), old_div(2.0,3)))
         
-        P = np.array(((2.0/3, 1.0/3),(1.0/3, 2.0/3),(2.0/3, 1.0/3)))
-        Q = np.array(((2.0/3, 1.0/3),(1.0/3, 2.0/3)))
+        P = np.array(((old_div(2.0,3), old_div(1.0,3)),(old_div(1.0,3), old_div(2.0,3)),(old_div(2.0,3), old_div(1.0,3))))
+        Q = np.array(((old_div(2.0,3), old_div(1.0,3)),(old_div(1.0,3), old_div(2.0,3))))
         H = discrete.divergence_kullbackleibler_symmetrised_pmf(P,Q, True)
-        self.assertTrue(np.allclose(H, np.array(((0.0,2.0/3),(2.0/3,0.0),(0.0,2.0/3)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(2.0,3)),(old_div(2.0,3),0.0),(0.0,old_div(2.0,3))))))
         H = discrete.divergence_kullbackleibler_symmetrised_pmf(Q)
-        self.assertTrue(np.allclose(H, np.array(((0.0,2.0/3),(2.0/3,0.0)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(2.0,3)),(old_div(2.0,3),0.0)))))
         
     def test_divergence_jensenshannon_pmf(self):
         #Immutability test
         X1 = np.random.randint(16, size=(10,10))
-        X1 = X1 / (1.0 * np.sum(X1, axis=1)[:,np.newaxis])
+        X1 = old_div(X1, (1.0 * np.sum(X1, axis=1)[:,np.newaxis]))
         X1_copy = np.copy(X1)
         X2 = np.random.randint(16, size=(10,10))
-        X2 = X2 / (1.0 * np.sum(X2, axis=1)[:,np.newaxis])
+        X2 = old_div(X2, (1.0 * np.sum(X2, axis=1)[:,np.newaxis]))
         X2_copy = np.copy(X2)        
         discrete.divergence_jensenshannon_pmf(X1_copy, X2_copy)
         self.assertTrue(np.all(X1_copy == X1) and np.all(X2_copy == X2))
@@ -284,10 +287,10 @@ class TestEntropy(unittest.TestCase):
         
         #Output dimensionality tests -- vectors
         self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((1.0,), (1.0,), (1.0,))), np.array(((1.0,), (1.0,), (1.0,)))).shape == (3,))
-        self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T).shape == (1,))
+        self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T).shape == (1,))
         #Tests using cartesian_product=True
         self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((1.0,), (1.0,), (1.0,))), np.array(((1.0,), (1.0,), (1.0,))), cartesian_product=True).shape == (3,3))
-        self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, np.array(((1.0/3,), (1.0/3,), (1.0/3,))).T, cartesian_product=True).shape == (1,1))        
+        self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, np.array(((old_div(1.0,3),), (old_div(1.0,3),), (old_div(1.0,3),))).T, cartesian_product=True).shape == (1,1))        
 
         self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array(1), np.array(1)) == 0)
         self.assertTrue(discrete.divergence_jensenshannon_pmf(np.array((1,)), np.array((1,))) == 0)
@@ -309,10 +312,10 @@ class TestEntropy(unittest.TestCase):
         Bins1 = np.linspace(-5,5,10000)
         P1 = norm.pdf(Bins1,loc=-0.5)
         P2 = norm.pdf(Bins1,loc=1.0)
-        P1 = P1 / np.sum(P1)
-        P2 = P2 / np.sum(P2)
+        P1 = old_div(P1, np.sum(P1))
+        P2 = old_div(P2, np.sum(P2))
         P = np.append(P1, P2)
-        P = P / np.sum(P)
+        P = old_div(P, np.sum(P))
         #Sample from component distributions
         I = np.random.choice(P.size, 10**6, p=P)
         #Get component indicator
@@ -390,7 +393,7 @@ class TestEntropy(unittest.TestCase):
         X = np.arange(3*4*5).reshape((3,4,5))
         self.assertTrue(isinstance(discrete.entropy(X), np.ndarray))
         self.assertTrue(discrete.entropy(X).shape == (3,4))
-        self.assertTrue(np.allclose(discrete.entropy(X), -np.log2(1.0/5)))
+        self.assertTrue(np.allclose(discrete.entropy(X), -np.log2(old_div(1.0,5))))
         
         np.random.seed(4759)
         X = np.random.randint(16, size=(10,10**4))
@@ -679,13 +682,13 @@ class TestEntropy(unittest.TestCase):
         X = np.arange(3*4*5).reshape((3,4,5))
         self.assertTrue(isinstance(discrete.entropy_cross(X,X), np.ndarray))
         self.assertTrue(discrete.entropy_cross(X,X).shape == (3,4))
-        self.assertTrue(np.allclose(discrete.entropy_cross(X,X), -np.log2(1.0/5)))
+        self.assertTrue(np.allclose(discrete.entropy_cross(X,X), -np.log2(old_div(1.0,5))))
         #Tests using cartesian_product=True  
         X = np.arange(3*4*5).reshape((3,4,5))
         self.assertTrue(isinstance(discrete.entropy_cross(X,X, cartesian_product=True), np.ndarray))
         self.assertTrue(discrete.entropy_cross(X,X, cartesian_product=True).shape == (3,4,3,4))
         H = discrete.entropy_cross(X,X, cartesian_product=True)        
-        self.assertTrue(np.allclose([H[i,j,i,j] for j in range(4) for i in range(3)], -np.log2(1.0/5)))        
+        self.assertTrue(np.allclose([H[i,j,i,j] for j in range(4) for i in range(3)], -np.log2(old_div(1.0,5))))        
         
         np.random.seed(4759)
         X = np.random.randint(16, size=(10,10**4))
@@ -907,7 +910,7 @@ class TestEntropy(unittest.TestCase):
         H = discrete.divergence_kullbackleibler(P2, P1, True, base=np.exp(1))
         Scales = Scales.reshape(-1)
         H = H.reshape(-1)
-        H_predicted = np.log(1.0/Scales) + (Scales**2 / 2) - 0.5
+        H_predicted = np.log(old_div(1.0,Scales)) + (old_div(Scales**2, 2)) - 0.5
         self.assertTrue(np.all(np.abs(H - H_predicted) < 2*1E-2))             
         
         #
@@ -1034,10 +1037,10 @@ class TestEntropy(unittest.TestCase):
         Bins1 = np.linspace(-5,5,10000)
         P1 = norm.pdf(Bins1,loc=-0.5)
         P2 = norm.pdf(Bins1,loc=1.0)
-        P1 = P1 / np.sum(P1)
-        P2 = P2 / np.sum(P2)
+        P1 = old_div(P1, np.sum(P1))
+        P2 = old_div(P2, np.sum(P2))
         P = np.append(P1, P2)
-        P = P / np.sum(P)
+        P = old_div(P, np.sum(P))
         #Sample from component distributions
         I = np.random.choice(P.size, 10**6, p=P)
         #Get component indicator
@@ -1186,14 +1189,14 @@ class TestEntropy(unittest.TestCase):
         self.assertTrue(discrete.divergence_kullbackleibler_symmetrised(np.ones((1,1)),np.ones((1,)),True).shape == (1,))
         self.assertTrue(discrete.divergence_kullbackleibler_symmetrised(np.ones((1,1)),np.ones((1,1)),True).shape == (1,1))        
 
-        self.assertTrue(np.allclose(discrete.divergence_kullbackleibler_symmetrised(np.array((1,2,1)), np.array((2,1,2))), 2.0/3))
+        self.assertTrue(np.allclose(discrete.divergence_kullbackleibler_symmetrised(np.array((1,2,1)), np.array((2,1,2))), old_div(2.0,3)))
         
         X = np.array(((1,2,1),(2,2,1),(1,1,2)))
         Y = np.array(((1,2,1),(1,2,2)))
         H = discrete.divergence_kullbackleibler_symmetrised(X,Y, True)
-        self.assertTrue(np.allclose(H, np.array(((0.0,2.0/3),(2.0/3,0.0),(0.0,2.0/3)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(2.0,3)),(old_div(2.0,3),0.0),(0.0,old_div(2.0,3))))))
         H = discrete.divergence_kullbackleibler_symmetrised(Y)
-        self.assertTrue(np.allclose(H, np.array(((0.0,2.0/3),(2.0/3,0.0)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(2.0,3)),(old_div(2.0,3),0.0)))))
         
         #
         # Tests using missing data (basic)
@@ -1522,9 +1525,9 @@ class TestEntropy(unittest.TestCase):
         P1 = norm.pdf(Bins1,loc=-0.5)
         P2 = norm.pdf(Bins1,loc=-0.0)
         P3 = norm.pdf(Bins1,loc=+0.5)     
-        P1 = P1 / np.sum(P1)
-        P2 = P2 / np.sum(P2)
-        P3 = P3 / np.sum(P3)        
+        P1 = old_div(P1, np.sum(P1))
+        P2 = old_div(P2, np.sum(P2))
+        P3 = old_div(P3, np.sum(P3))        
         #Sample from component distributions
         I = np.random.choice(P1.size, 10**6, p=P1)
         J = np.random.choice(P1.size, 10**6, p=P2)
@@ -1603,7 +1606,7 @@ class TestEntropy(unittest.TestCase):
         discrete.information_variation(X1,X2)
         self.assertTrue(np.all(X1_copy == X1) and np.all(X2_copy == X2))        
 
-        self.assertTrue(np.allclose(discrete.information_variation(np.array((1,2,1)), np.array((1,2,2))), 4.0/3))
+        self.assertTrue(np.allclose(discrete.information_variation(np.array((1,2,1)), np.array((1,2,2))), old_div(4.0,3)))
         self.assertTrue(np.allclose(discrete.information_variation(np.array((1,2,1)), np.array((1,2,2))), 2 * discrete.entropy_conditional(np.array((1,2,1)), np.array((1,2,2)))))
         
         self.assertTrue(discrete.information_variation(np.array(1),np.array(1)).shape == tuple())
@@ -1622,9 +1625,9 @@ class TestEntropy(unittest.TestCase):
         X = np.array(((1,2,1),(2,2,1),(1,1,2)))
         Y = np.array(((1,2,1),(1,2,2)))
         H = discrete.information_variation(X,Y, True)
-        self.assertTrue(np.allclose(H, np.array(((0.0,4.0/3),(4.0/3,4.0/3),(4.0/3,4.0/3)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(4.0,3)),(old_div(4.0,3),old_div(4.0,3)),(old_div(4.0,3),old_div(4.0,3))))))
         H = discrete.information_variation(Y)
-        self.assertTrue(np.allclose(H, np.array(((0.0,4.0/3),(4.0/3,0)))))
+        self.assertTrue(np.allclose(H, np.array(((0.0,old_div(4.0,3)),(old_div(4.0,3),0)))))
                 
         #
         # Tests using missing data (basic)
@@ -1693,23 +1696,23 @@ class TestEntropy(unittest.TestCase):
         discrete.information_mutual_normalised(X1,X2)
         self.assertTrue(np.all(X1_copy == X1) and np.all(X2_copy == X2))
         
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2))) == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2)/discrete.entropy(np.array((2,1,2)), base=2))
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'Y') == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2)/discrete.entropy(np.array((2,1,2)), base=2))        
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'X') == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2)/discrete.entropy(np.array((1,2,2)), base=2))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), ' x + Y '), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=np.exp(1))/(discrete.entropy(np.array((1,2,2)), base=np.exp(1))+discrete.entropy(np.array((2,1,2)), base=np.exp(1)))))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MIN'), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2)))))))      
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MAX'), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2)))))))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'XY'), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/discrete.entropy_joint(np.vstack((np.array((2,1,2)), np.array((1,2,2)))))))
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'SQRT'), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.sqrt(discrete.entropy(np.array((1,2,2)))*discrete.entropy(np.array((2,1,2))))))        
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2))) == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2),discrete.entropy(np.array((2,1,2)), base=2)))
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'Y') == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2),discrete.entropy(np.array((2,1,2)), base=2)))        
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'X') == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=2),discrete.entropy(np.array((1,2,2)), base=2)))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), ' x + Y '), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), base=np.exp(1)),(discrete.entropy(np.array((1,2,2)), base=np.exp(1))+discrete.entropy(np.array((2,1,2)), base=np.exp(1))))))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MIN'), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2))))))))      
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MAX'), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2))))))))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'XY'), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),discrete.entropy_joint(np.vstack((np.array((2,1,2)), np.array((1,2,2))))))))
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'SQRT'), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.sqrt(discrete.entropy(np.array((1,2,2)))*discrete.entropy(np.array((2,1,2)))))))        
         #Tests using cartesian_product=True
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True) == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True, base=2)/discrete.entropy(np.array((2,1,2)),base=2))
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'Y', cartesian_product=True) == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=2)/discrete.entropy(np.array((2,1,2)),base=2))        
-        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'X', cartesian_product=True) == discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=2)/discrete.entropy(np.array((1,2,2)),base=2))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), ' x + Y ', cartesian_product=True), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=np.exp(1))/(discrete.entropy(np.array((1,2,2)),base=np.exp(1))+discrete.entropy(np.array((2,1,2)),base=np.exp(1)))))
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MIN', cartesian_product=True), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2)))))))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MAX', cartesian_product=True), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2)))))))        
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'XY', cartesian_product=True), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/discrete.entropy_joint(np.vstack((np.array((2,1,2)), np.array((1,2,2)))))))
-        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'SQRT', cartesian_product=True), discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)))/np.sqrt(discrete.entropy(np.array((1,2,2)))*discrete.entropy(np.array((2,1,2))))))        
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True) == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True, base=2),discrete.entropy(np.array((2,1,2)),base=2)))
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'Y', cartesian_product=True) == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=2),discrete.entropy(np.array((2,1,2)),base=2)))        
+        self.assertTrue(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'X', cartesian_product=True) == old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=2),discrete.entropy(np.array((1,2,2)),base=2)))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), ' x + Y ', cartesian_product=True), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2)), cartesian_product=True,base=np.exp(1)),(discrete.entropy(np.array((1,2,2)),base=np.exp(1))+discrete.entropy(np.array((2,1,2)),base=np.exp(1))))))
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MIN', cartesian_product=True), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2))))))))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'MAX', cartesian_product=True), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.min((discrete.entropy(np.array((1,2,2))),discrete.entropy(np.array((2,1,2))))))))        
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'XY', cartesian_product=True), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),discrete.entropy_joint(np.vstack((np.array((2,1,2)), np.array((1,2,2))))))))
+        self.assertTrue(np.allclose(discrete.information_mutual_normalised(np.array((1,2,2)), np.array((2,1,2)), 'SQRT', cartesian_product=True), old_div(discrete.information_mutual(np.array((1,2,2)), np.array((2,1,2))),np.sqrt(discrete.entropy(np.array((1,2,2)))*discrete.entropy(np.array((2,1,2)))))))        
         
         self.assertTrue(discrete.information_mutual_normalised(np.ones(5),np.ones(5)).size==1)
         self.assertTrue(np.isnan(discrete.information_mutual_normalised(np.ones(5),np.ones(5))))        
@@ -1873,7 +1876,7 @@ class TestEntropy(unittest.TestCase):
                 Denominator = np.sqrt(discrete.entropy((2,2,2,1), estimator=1, base=3) * discrete.entropy((1,2,1,2), estimator=1, base=3))                
             else:
                 raise ValueError("Unsupported argument")
-            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=None, Alphabet_Y=None), Numerator / Denominator))
+            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=None, Alphabet_Y=None), old_div(Numerator, Denominator)))
         #No explicit alphabet -- Cartesian product
         for norm_factor in ('Y','X','X+Y','MIN','MAX','XY','SQRT'):
             self.assertTrue(np.all(discrete.information_mutual_normalised(np.array(((1,2,1,2),(2,2,2,1))), None, norm_factor, estimator=1, Alphabet_X=None) != discrete.information_mutual_normalised(np.array(((1,2,1,2),(2,2,2,1))), None, norm_factor, Alphabet_X=None)))        
@@ -1912,9 +1915,9 @@ class TestEntropy(unittest.TestCase):
                 Denominator3 = np.sqrt(discrete.entropy((2,2,2,1), Alphabet_X=(1,2,3), estimator=1, base=3) * discrete.entropy((1,2,1,2), Alphabet_X=(1,2,3), estimator=1, base=3))                
             else:
                 raise ValueError("Unsupported argument")
-            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=None, Alphabet_Y=(1,2,3)), Numerator1 / Denominator1))
-            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=(1,2,3), Alphabet_Y=None), Numerator2 / Denominator2))
-            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=(1,2,3), Alphabet_Y=(1,2,3)), Numerator3 / Denominator3))        
+            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=None, Alphabet_Y=(1,2,3)), old_div(Numerator1, Denominator1)))
+            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=(1,2,3), Alphabet_Y=None), old_div(Numerator2, Denominator2)))
+            self.assertTrue(np.allclose(discrete.information_mutual_normalised((1,2,1,2),(2,2,2,1), norm_factor, estimator=1, Alphabet_X=(1,2,3), Alphabet_Y=(1,2,3)), old_div(Numerator3, Denominator3)))        
         #Larger alphabet -- Cartesian product
         for norm_factor in ('Y','X','X+Y','MIN','MAX','XY','SQRT'):        
             self.assertTrue(np.all(discrete.information_mutual_normalised(np.array(((1,2,1,2),(2,2,2,1))), None, norm_factor, estimator=1, Alphabet_X=np.array(((1,2,3),(1,2,3)))) != discrete.information_mutual_normalised(np.array(((2,2,2,1),(2,2,2,1))), None, norm_factor, Alphabet_X=np.array(((1,2,3),(1,2,3))))))
@@ -2703,21 +2706,21 @@ class TestEntropy(unittest.TestCase):
             self.assertTrue(np.allclose(np.sum(P) + n*P_0, 1))
         #Some hand-worked examples
         #[1 2 8]; 0 empty bins
-        Theta = np.array((1,2,8)) / 11.0
-        t_k = 1 / 3.0
-        Lambda = (1 - np.sum(Theta**2)) / ((11-1) * np.sum((t_k - Theta)**2))
+        Theta = old_div(np.array((1,2,8)), 11.0)
+        t_k = old_div(1, 3.0)
+        Lambda = old_div((1 - np.sum(Theta**2)), ((11-1) * np.sum((t_k - Theta)**2)))
         Theta_shrink = Lambda*t_k + (1-Lambda)*Theta
         self.assertTrue(np.all(Theta_shrink == discrete._estimate_probabilities(np.array((1,2,8)), 'james-stein',0)[0]))
         #0.1 0.2 0.8; 1 empty bin
-        Theta = np.array((1,2,8)) / 11.0
-        t_k = 1 / 4.0
-        Lambda = (1 - np.sum(Theta**2)) / ((11-1) * (np.sum((t_k - Theta)**2)+(t_k**2)))
+        Theta = old_div(np.array((1,2,8)), 11.0)
+        t_k = old_div(1, 4.0)
+        Lambda = old_div((1 - np.sum(Theta**2)), ((11-1) * (np.sum((t_k - Theta)**2)+(t_k**2))))
         Theta_shrink = Lambda*t_k + (1-Lambda)*Theta
         self.assertTrue(np.all(Theta_shrink == discrete._estimate_probabilities(np.array((1,2,8)), 'james-stein',1)[0]))        
         #0.1 0.2 0.8; 2 empty bins
-        Theta = np.array((1,2,8)) / 11.0
-        t_k = 1 / 5.0
-        Lambda = (1 - np.sum(Theta**2)) / ((11-1) * (np.sum((t_k - Theta)**2)+(2*t_k**2)))
+        Theta = old_div(np.array((1,2,8)), 11.0)
+        t_k = old_div(1, 5.0)
+        Lambda = old_div((1 - np.sum(Theta**2)), ((11-1) * (np.sum((t_k - Theta)**2)+(2*t_k**2))))
         Theta_shrink = Lambda*t_k + (1-Lambda)*Theta
         self.assertTrue(np.all(Theta_shrink == discrete._estimate_probabilities(np.array((1,2,8)), 'james-stein',2)[0]))
         
@@ -2735,25 +2738,25 @@ class TestEntropy(unittest.TestCase):
                 self.assertTrue(np.allclose(np.sum(P) + n*P_0, 1))
         #Some hand-worked examples
         #[1 2 8]; 0 empty bins
-        Theta = np.array((1,2,8)) / 11.0
+        Theta = old_div(np.array((1,2,8)), 11.0)
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'ML',0)[0]))
-        Theta = (1.0/3+np.array((1,2,8))) / (11.0 + 1.0)
+        Theta = old_div((old_div(1.0,3)+np.array((1,2,8))), (11.0 + 1.0))
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'PERKS',0)[0]))
-        Theta = (np.sqrt(11)/3+np.array((1,2,8))) / (11.0 + np.sqrt(11))        
+        Theta = old_div((old_div(np.sqrt(11),3)+np.array((1,2,8))), (11.0 + np.sqrt(11)))        
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'MINIMAX',0)[0]))       
         #0.1 0.2 0.8; 1 empty bin
-        Theta = np.array((1,2,8)) / 11.0
+        Theta = old_div(np.array((1,2,8)), 11.0)
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'ML',1)[0]))
-        Theta = (1.0/4+np.array((1,2,8))) / (11.0 + 1.0)
+        Theta = old_div((old_div(1.0,4)+np.array((1,2,8))), (11.0 + 1.0))
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'PERKS',1)[0]))
-        Theta = (np.sqrt(11)/4+np.array((1,2,8))) / (11.0 + np.sqrt(11))        
+        Theta = old_div((old_div(np.sqrt(11),4)+np.array((1,2,8))), (11.0 + np.sqrt(11)))        
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'MINIMAX',1)[0]))
         #0.1 0.2 0.8; 2 empty bins
-        Theta = np.array((1,2,8)) / 11.0
+        Theta = old_div(np.array((1,2,8)), 11.0)
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'ML',2)[0]))
-        Theta = (1.0/5+np.array((1,2,8))) / (11.0 + 1.0)
+        Theta = old_div((old_div(1.0,5)+np.array((1,2,8))), (11.0 + 1.0))
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'PERKS',2)[0]))
-        Theta = (np.sqrt(11)/5+np.array((1,2,8))) / (11.0 + np.sqrt(11))        
+        Theta = old_div((old_div(np.sqrt(11),5)+np.array((1,2,8))), (11.0 + np.sqrt(11)))        
         self.assertTrue(np.all(Theta == discrete._estimate_probabilities(np.array((1,2,8)), 'MINIMAX',2)[0]))       
         
         #Good-Turing estimator
@@ -2833,7 +2836,7 @@ class TestEntropy(unittest.TestCase):
         N_r = N_r.tolist()
         Counts = []
         for r, n_r in N_r:
-            for i in xrange(n_r):
+            for i in range(n_r):
                 Counts.append(r)
         Counts = np.array(Counts)
         P = discrete._estimate_probabilities(Counts, 'good-turing',1)[0]


### PR DESCRIPTION
Basically what I did here was run `futurize -w . --stage2` on the code, see http://python-future.org/futurize.html for details.

The main changes are importing the new `range` function and using that instead of `xrange`, and also importing  `old_div`, which mimics Python2's division for both Python 2 and 3. What would be preferable is to `from __future__ import division` (which enables Python 3's division), and then using either `//` or `/` depending on if you want integer division or not. See [here](https://docs.python.org/3/whatsnew/2.2.html#pep-238-changing-the-division-operator) for details. I'm not really able to tell from your code which kind of division you want. I assume it's not floor division `//`, but I'm not certain.