### PR TITLE
Contrains dependency version of scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'pandas>=0.20.2'
         'numpy>=1.9.2',
-        'scikit-learn>=0.16.0',
+        'scikit-learn>=0.16.0,<=0.24',
         'scipy>=1.0.1',
         'future>=0.16.0'
     ],


### PR DESCRIPTION
Current implementation of the library is not compatible with the recently released Scikit-learn 1.0, but is compatible with 0.24.
This is a temporary change to ensure a proper installation of the package.